### PR TITLE
Allow override of asURL in library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "CleevioCore",
-        "repositoryURL": "git@gitlab.cleevio.cz:cleevio-dev-ios/CleevioCore",
+        "repositoryURL": "https://github.com/cleevio/CleevioCore.git",
         "state": {
           "branch": null,
           "revision": "593b5d1011ad0aa6963ea2d8bf2ddc5e59caa917",
@@ -12,11 +12,11 @@
       },
       {
         "package": "CleevioStorageLibrary",
-        "repositoryURL": "git@gitlab.cleevio.cz:cleevio-dev-ios/CleevioStorage",
+        "repositoryURL": "https://github.com/cleevio/CleevioStorage.git",
         "state": {
           "branch": null,
-          "revision": "0fd34beefca537809ee6d72d69ccb0980a203dab",
-          "version": "0.4.2"
+          "revision": "87ed8a6189cba4c877367dd2e57161080e6d8cad",
+          "version": "0.4.3"
         }
       },
       {

--- a/Sources/RouterBytes/APIRouter.swift
+++ b/Sources/RouterBytes/APIRouter.swift
@@ -69,6 +69,7 @@ public protocol APIRouter<RequestBody>: Sendable {
     func encode(_ value: RequestBody) throws -> Data?
     func decode<T: Decodable>(_ type: T.Type, from data: Data) throws  -> T
     func contentType(from body: RequestBody) -> ContentType
+    func asURL(hostname: URL) throws -> URL
 }
 
 public extension APIRouter {


### PR DESCRIPTION
Welcome addition for debugging non-standard API, e.g. where JSON data is used as a query parameter